### PR TITLE
Tags custom autocomplete 

### DIFF
--- a/ckanext/scheming/ckan_dataset_ar.yaml
+++ b/ckanext/scheming/ckan_dataset_ar.yaml
@@ -24,9 +24,10 @@ dataset_fields:
   preset: fluent_markdown
   form_placeholder: eg. Some useful notes about the data
 
-- field_name: keywords
-  label: Keywords
-  preset: fluent_tags
+- field_name: tag_string
+  label: Tags
+  preset: tag_string_autocomplete
+  form_placeholder: eg. economy, mental health, government
 
 - field_name: license_id
   label: License

--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -44,7 +44,9 @@
         "form_attrs": {
           "data-module": "autocomplete",
           "data-module-tags": "",
-          "data-module-source": "/api/2/util/tag/autocomplete?incomplete=?",
+          "data-module-createtags": "false",
+          "data-module-interval": "50",
+          "data-module-source": "/api/2/util/vocab/tag/autocomplete?incomplete=?",
           "class": ""
         }
       }


### PR DESCRIPTION
Fix for:  https://github.com/FCSCOpendata/ckanext-fcscopendata/issues/28

Tags autocomplete with categories tags list suggestion. 

Example Screenshot: 

<img width="1008" alt="Screen Shot 2022-03-06 at 9 29 47 AM" src="https://user-images.githubusercontent.com/87696933/156908338-153a2f58-f7e9-4c5a-aee9-69ea2ee10f17.png">
