### PR TITLE
Added theme select UI  in dataset create/update page. 

### DIFF
--- a/ckanext/scheming/ckan_dataset_ar.yaml
+++ b/ckanext/scheming/ckan_dataset_ar.yaml
@@ -38,6 +38,10 @@ dataset_fields:
   label: Organization
   preset: dataset_organization
 
+- field_name: owner_theme
+  label: Theme
+  preset: dataset_theme
+  
 - field_name: url
   label: Source
   form_placeholder: http://example.com/dataset.json

--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -59,6 +59,13 @@
       }
     },
     {
+      "preset_name": "dataset_theme",
+      "values": {
+        "validators": "unicode",
+        "form_snippet": "group.html"
+      }
+    },
+    {
       "preset_name": "resource_url_upload",
       "values": {
         "validators": "ignore_missing unicode remove_whitespace",

--- a/ckanext/scheming/templates/scheming/form_snippets/_group_select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/_group_select.html
@@ -1,0 +1,34 @@
+{% import 'macros/form.html' as form %}
+
+{# this snippet is meant to be called from organization.html,
+not used as a form_snippet directly #}
+
+{% macro _group() %}
+  {% set existing_group = data.owner_theme or data.group_id %}
+  {% call form.input_block('field-{{field.field_name}}',
+    label=h.scheming_language_text(field.label),
+    error=errors[field.field_name],
+    is_required=group_required,
+    classes=['form-group', 'control-medium'],
+    extra_html=caller() if caller,
+    ) %}
+    <div {{
+      form.attributes(field.form_attrs) if 'form_attrs' in field else '' }}>
+      <select id="field-{{field.field_name}}" name="{{field.field_name}}" data-module="autocomplete">
+        field.get('form_select_attrs', {'data-module':'autocomplete'})) }}>
+      {% if not group_required or field.get('form_include_blank_choice', false) %}
+        <option value="">{% if not group_required
+          %}{{ _('No Group') }}{% endif %}</option>
+      {% endif %}
+      {% for group in groups_available %}
+        {% set selected_group = existing_group == group.id %}
+        {{ group_option_tag(group, selected_group) }}
+      {% endfor %}
+    </select>
+    </div>
+  {% endcall %}
+{% endmacro %}
+
+{% call _group() %}
+  {%- snippet 'scheming/form_snippets/help_text.html', field=field %}
+{% endcall %}

--- a/ckanext/scheming/templates/scheming/form_snippets/group.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/group.html
@@ -1,0 +1,22 @@
+{# This is specific to datasets' owner_theme field and won't work #}
+{# if used with other fields #}
+
+
+{% macro group_option_tag(group, selected_group) %}
+  {% block group_option scoped %}
+    <option value="{{ group.id }}"{%
+      if selected_group %} selected="selected"{% endif
+      %}>{{ group.display_name }}</option>
+  {% endblock %}
+{% endmacro %}
+
+  <div data-module="dataset-visibility">
+  {% snippet "scheming/form_snippets/_group_select.html",
+    field=field,
+    data=data,
+    errors=errors,
+    groups_available=h.groups_available('create_dataset'),
+    group_required=not h.check_config_permission('create_unowned_dataset')
+      or h.scheming_field_required(field),
+    group_option_tag=group_option_tag %}
+  </div>


### PR DESCRIPTION
Fix for #https://github.com/FCSCOpendata/ckanext-fcscopendata/issues/27
Screenshot:
<img width="895" alt="Screen Shot 2022-03-09 at 2 17 47 PM" src="https://user-images.githubusercontent.com/87696933/157403097-bcdfa815-6c72-4a5b-bfff-65e304261d07.png">

Note it is dependent with [#35](https://github.com/FCSCOpendata/ckanext-fcscopendata/pull/35)
## Changes in this PR: 
- Created templates preset for group aka theme select UI. 
- Updated scheming YAML file adding preset theme select field. 
