### PR TITLE
Fetch group_list from the db

### DIFF
--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -10,6 +10,8 @@ from jinja2 import Environment
 from ckantoolkit import config, _
 
 from ckanapi import LocalCKAN, NotFound, NotAuthorized
+import ckan.model as model
+import ckan.lib.dictization.model_dictize as model_dictize
 
 all_helpers = {}
 
@@ -433,3 +435,13 @@ def scheming_flatten_subfield(subfield, data):
         for k in record:
             flat[prefix + k] = record[k]
     return flat
+
+@helper
+def get_group_list():
+    context = {'model':model}
+    q = model.Session.query(model.Group) \
+        .filter(model.Group.is_organization == False) \
+        .filter(model.Group.state == 'active')
+    groups = q.all()
+    group_list = model_dictize.group_list_dictize(groups, context)
+    return group_list

--- a/ckanext/scheming/templates/scheming/form_snippets/_group_select.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/_group_select.html
@@ -22,6 +22,7 @@ not used as a form_snippet directly #}
         field.get('form_select_attrs', {'data-module':'autocomplete'})) }}>
       {% if not group_required or field.get('form_include_blank_choice', false) %}
       {% endif %}
+      {% set groups_available = h.get_group_list() %}
       {% for group in groups_available %}
         {% set selected_group = group.id in existing_group %}
         {{ group_option_tag(group, selected_group) }}


### PR DESCRIPTION
This PR adds a helper function to fetch the groups from the db directly bypassing the permission issues caused when accessing from the action endpoint.